### PR TITLE
Update copyright and edX Help Center link

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,8 +68,8 @@
               <ul class="list--links">
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/">
-                    <h4 class="item-link__title">EdX Learner's Guide</h4>
+                  <a class="item-link__action" href="https://support.edx.org/hc/en-us/">
+                    <h4 class="item-link__title">EdX Learner Help Center</h4>
                     <div class="item-link__copy">
                       <p>Help for learners taking a course on edx.org.</p>
                     </div>
@@ -305,7 +305,7 @@
 
     <footer class="footer--primary" role="contentinfo">
       <div class="content--copyright">
-        <p class="copyright__copy">Copyright &copy; 2017 <a href="http://www.edx.org">edX Inc.</a></p>
+        <p class="copyright__copy">Copyright &copy; 2018 <a href="http://www.edx.org">edX Inc.</a></p>
       </div>
     </footer>
   </div>


### PR DESCRIPTION
- updated copyright from 2017 to 2018
- updated edX Learner Guide from the RTD project to the current edX
Help Center, in the edx.org page section.