### PR TITLE
Add Hawthorn section to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,46 @@
 
               </ul>
             </section>
+                  <section>
+              <h3 class="item-audience__title"><a name="release"></a>Open edX: Hawthorn Release</h3>
+
+              <div class="item-audience__copy">
+                <p>Documentation for the Hawthorn Open edX release, in progress. </p>
+              </div>
+
+              <ul class="list--links">
+<!--                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/ginkgo.html">
+                    <h4 class="item-link__title">Hawthorn Release Notes</h4>
+                    <div class="item-link__copy">
+                      <p>Summary of the changes in the Hawthorn release of the Open edX platform.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-hawthorn.master/">
+                    <h4 class="item-link__title">Building and Running an Open edX Course: Hawthorn Release</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
+                    </div>
+                  </a>
+                </li> -->
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-hawthorn.master/">
+                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform: Hawthorn Release</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for system administrators setting up an Open edX installation.</p>
+                    </div>
+                  </a>
+                </li>
+
+
+              </ul>
+
+            </section>
+
             <section class="item-audience item-audience--release">
               <h3 class="item-audience__title"><a name="release"></a>Open edX: Ginkgo Release</h3>
 

--- a/index.html
+++ b/index.html
@@ -125,7 +125,8 @@
 
               </ul>
             </section>
-                  <section>
+
+            <section>
               <h3 class="item-audience__title"><a name="release"></a>Open edX: Hawthorn Release</h3>
 
               <div class="item-audience__copy">
@@ -164,7 +165,8 @@
               </ul>
 
             </section>
-
+<br>
+<hr>>
             <section class="item-audience item-audience--release">
               <h3 class="item-audience__title"><a name="release"></a>Open edX: Ginkgo Release</h3>
 


### PR DESCRIPTION
Add a section for Hawthorn docs to the landing page. For now, it shows only the ICR guide. Later steps:
* Add the other named release guides
* Remove the Ginkgo docs after Hawthorn release.