### PR TITLE
Add Building and Running guide to Hawthorn section

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
                       <p>Summary of the changes in the Hawthorn release of the Open edX platform.</p>
                     </div>
                   </a>
-                </li>
+                </li>  -->
 
                 <li class="item-link">
                   <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-hawthorn.master/">
@@ -150,7 +150,7 @@
                       <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
                     </div>
                   </a>
-                </li> -->
+                </li>
 
                 <li class="item-link">
                   <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-hawthorn.master/">


### PR DESCRIPTION
Adding the Building and Running guide to the Hawthorn section of the landing page.