### PR TITLE
Condensed index page

### DIFF
--- a/course-staff.html
+++ b/course-staff.html
@@ -47,7 +47,7 @@
             </abbr>
           </h1>
 
-          <h2 class="header__tagline">Documentation for edx.org and the Open edX Community</h2>
+          <h2 class="header__tagline">Documentation for edx.org Partners</h2>
         </div>
       </header>
     </div>
@@ -59,60 +59,32 @@
 
           <div class="list--docs">
             <section class="item-audience item-audience--partners">
-              <h3 class="item-audience__title"><a name="partners"></a>edX Documentation Resources</h3>
+              <h3 class="item-audience__title"><a name="partners"></a>Documentation Resources for edx.org Partner Course Teams</h3>
 
               <div class="item-audience__copy">
-                <p>EdX provides user documentation for a variety of audiences: edx.org learners, course teams, developers, and researchers. </p>
+                <p>Information for edX partner course teams about how to develop courses on edx.org.</p>
               </div>
 
               <ul class="list--links">
 
                 <li class="item-link">
-                  <a class="item-link__action" href="https://support.edx.org/hc/en-us/">
-                    <h4 class="item-link__title">Learners</h4>
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/">
+                    <h4 class="item-link__title">Building and Running an edX Course</h4>
                     <div class="item-link__copy">
-                      <p>Are you a learner taking a course on edx.org? Get help from the EdX Learner Help Center.</p>
+                      <p>Instructions for course teams that are creating courses to run on the edx.org website.</p>
                     </div>
                   </a>
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/course-staff.html">
-                    <h4 class="item-link__title">Course Teams</h4>
+                  <a class="item-link__action" href="https://partners.edx.org/announcements?f%5B0%5D=field_announcement_type%3A51">
+                    <h4 class="item-link__title">Product Update Announcements</h4>
                     <div class="item-link__copy">
-                      <p>Information and instructions for course teams that are creating courses to run on the edx.org website.</p>
+                      <p>Product update announcements on the edX partner portal.</p>
                     </div>
                   </a>
                 </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/">
-                    <h4 class="item-link__title">Developers</h4>
-                    <div class="item-link__copy">
-                      <p>Guidelines and resources for developers who are extending and contributing to the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/operators.html">
-                    <h4 class="item-link__title">Open edX Operators</h4>
-                    <div class="item-link__copy">
-                      <p>Information about setting up and operating instances of the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/researchers.html">
-                    <h4 class="item-link__title">Researchers</h4>
-                    <div class="item-link__copy">
-                      <p>Descriptions of the visualizations, metrics, and tables that present edx.org course data to edX partner course teams, researchers, and data czars.</p>
-                    </div>
-                  </a>
-                </li>
-
-              </ul>
+          </ul>
             </section>
    
         </article>

--- a/index.html
+++ b/index.html
@@ -59,272 +59,62 @@
 
           <div class="list--docs">
             <section class="item-audience item-audience--partners">
-              <h3 class="item-audience__title"><a name="partners"></a>edx.org</h3>
+              <h3 class="item-audience__title"><a name="partners"></a>edX Documentation Resources</h3>
 
               <div class="item-audience__copy">
-                <p>Documentation for edx.org learners, course teams, and researchers. </p>
+                <p>EdX provides user documentation for a variety of audiences: edx.org learners, course teams, developers, and researchers. </p>
               </div>
 
               <ul class="list--links">
 
                 <li class="item-link">
                   <a class="item-link__action" href="https://support.edx.org/hc/en-us/">
-                    <h4 class="item-link__title">EdX Learner Help Center</h4>
+                    <h4 class="item-link__title">Learners</h4>
                     <div class="item-link__copy">
-                      <p>Help for learners taking a course on edx.org.</p>
+                      <p>Are you a learner taking a course on edx.org? Get help from the EdX Learner Help Center.</p>
                     </div>
                   </a>
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/">
-                    <h4 class="item-link__title">Building and Running an edX Course</h4>
+                  <a class="item-link__action" href="http://docs.edx.org/course-staff">
+                    <h4 class="item-link__title">Course Teams</h4>
                     <div class="item-link__copy">
-                      <p>Instructions for course teams that are creating  courses to run on the edx.org website.</p>
+                      <p>Information and instructions for course teams that are creating courses to run on the edx.org website.</p>
                     </div>
                   </a>
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" rel="external" href=https://partners.edx.org/announcements?f%5B0%5D=field_announcement_type%3A51>
-
-                    <h4 class="item-link__title">Product Update Announcements</h4>
+                  <a class="item-link__action" href="docs.edx.org/developers">
+                    <h4 class="item-link__title">Developers</h4>
                     <div class="item-link__copy">
-                      <p>Product update announcements on our Partner portal.</p>
+                      <p>Guidelines and resources for developers who are extending and contributing to the Open edX platform.</p>
                     </div>
                   </a>
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-insights/en/latest/">
-                    <h4 class="item-link__title">Using edX Insights</h4>
+                  <a class="item-link__action" href="docs.edx.org/operators">
+                    <h4 class="item-link__title">Open edX Operators</h4>
                     <div class="item-link__copy">
-                      <p>Descriptions of the visualizations, metrics, and tables that present edx.org course data to course teams.</p>
+                      <p>Information about setting up and operating instances of the Open edX platform.</p>
                     </div>
                   </a>
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/devdata/en/latest/">
-                    <h4 class="item-link__title">EdX Research Guide</h4>
+                  <a class="item-link__action" href="docs.edx.org/researchers">
+                    <h4 class="item-link__title">Researchers</h4>
                     <div class="item-link__copy">
-                      <p>A reference for edX partner researchers and data czars.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" rel="external" href="http://edx.readthedocs.io/projects/edx-release-notes/en/latest/">
-
-                    <h4 class="item-link__title">Release Notes (Archived)</h4>
-                    <div class="item-link__copy">
-                      <p>Weekly release notes up to May 2017.</p>
+                      <p>Descriptions of the visualizations, metrics, and tables that present edx.org course data to edX partner course teams, researchers, and data czars.</p>
                     </div>
                   </a>
                 </li>
 
               </ul>
             </section>
-
-            <section class="item-audience item-audience--release">
-              <h3 class="item-audience__title"><a name="release"></a><a name="hawthorn"></a>Open edX: Hawthorn Release</h3>
-
-              <div class="item-audience__copy">
-                <p>Documentation for the Hawthorn Open edX release, in progress. </p>
-              </div>
-
-              <ul class="list--links">
-<!--                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/ginkgo.html">
-                    <h4 class="item-link__title">Hawthorn Release Notes</h4>
-                    <div class="item-link__copy">
-                      <p>Summary of the changes in the Hawthorn release of the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>  -->
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-hawthorn.master/">
-                    <h4 class="item-link__title">Building and Running an Open edX Course: Hawthorn Release</h4>
-                    <div class="item-link__copy">
-                      <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-hawthorn.master/">
-                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform: Hawthorn Release</h4>
-                    <div class="item-link__copy">
-                      <p>Instructions for system administrators setting up an Open edX installation.</p>
-                    </div>
-                  </a>
-                </li>
-
-
-              </ul>
-
-            </section>
-
-            <section class="item-audience item-audience--release">
-              <h3 class="item-audience__title"><a name="release"></a><a name="ginkgo"></a>Open edX: Ginkgo Release</h3>
-
-              <div class="item-audience__copy">
-                <p>Documentation for the Ginkgo Open edX release, available 15 August 2017. </p>
-              </div>
-
-              <ul class="list--links">
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/ginkgo.html">
-                    <h4 class="item-link__title">Ginkgo Release Notes</h4>
-                    <div class="item-link__copy">
-                      <p>Summary of the changes in the Ginkgo release of the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-ginkgo.master/">
-                    <h4 class="item-link__title">Building and Running an Open edX Course: Ginkgo Release</h4>
-                    <div class="item-link__copy">
-                      <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <!-- This book is no longer maintained.
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-platform-api/en/eucalyptus.1/">
-                    <h4 class="item-link__title">Open edX Platform APIs: Eucalyptus Release</h4>
-                    <div class="item-link__copy">
-                      <p>Descriptions of the REST APIs for the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                -->
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-ginkgo.master/">
-                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform: Ginkgo Release</h4>
-                    <div class="item-link__copy">
-                      <p>Instructions for system administrators setting up an Open edX installation.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-ginkgo.master/">
-                    <h4 class="item-link__title">Open edX Learner's Guide: Ginkgo Release</h4>
-                    <div class="item-link__copy">
-                      <p>Information for learners taking an Open edX course.</p>
-                    </div>
-                  </a>
-                </li>
-
-              </ul>
-
-            </section>
-
-            <section class="item-audience item-audience--release">
-              <h3 class="item-audience__title"><a name="dev"></a>Documentation for Developers</h3>
-
-              <div class="item-link__copy">
-                <p>Guidelines and resources for developers who are extending and contributing to the Open edX platform.</p>
-              </div>
-
-              <ul class="list--links">
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/">
-                    <h4 class="item-link__title">Open edX Developer's Guide</h4>
-                    <div class="item-link__copy">
-                      <p>Reference for developers contributing to the edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/xblock-tutorial/en/latest//">
-                    <h4 class="item-link__title">Open edX XBlock Tutorial</h4>
-                    <div class="item-link__copy">
-                      <p>Step-by-step instructions for building an XBlock, the component architecture for the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/xblock/en/latest/">
-                    <h4 class="item-link__title">Open edX XBlock API Guide</h4>
-                    <div class="item-link__copy">
-                      <p>API information for developers extending Open edX with XBlocks.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-data-analytics-api/en/latest/index.html">
-                    <h4 class="item-link__title">Open edX Data Analytics API - Alpha Version 0</h4>
-                    <div class="item-link__copy">
-                      <p>Documentation for the Open edX Data Analytics REST API.</p>
-                    </div>
-                  </a>
-                </li>
-
-              </ul>
-            </section>
-
-            <section class="item-audience item-audience--release">
-              <h3 class="item-audience__title"><a name="latest"></a>Open edX: "Latest" Documentation</h3>
-
-              <div class="item-audience__copy">
-                <p>Documentation for Open edX users who are following the master version of the platform. These guides can include changes made after the Ginkgo release.</p>
-              </div>
-
-              <ul class="list--links">
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/">
-                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform</h4>
-                    <div class="item-link__copy">
-                      <p>Instructions for system administrators setting up an Open edX installation.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/">
-                    <h4 class="item-link__title">Building and Running an Open edX Course</h4>
-                    <div class="item-link__copy">
-                      <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/">
-                    <h4 class="item-link__title">Open edX Learner's Guide</h4>
-                    <div class="item-link__copy">
-                      <p>Help for learners taking an Open edX course.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/">
-                    <h4 class="item-link__title">edX Open Learning XML Guide - Alpha Version</h4>
-                    <div class="item-link__copy">
-                      <p>Reference for course teams who use open learning XML (OLX) to build courses.</p>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-              <div class="item-audience__copy">
-                <p>Looking for documentation for the last Open edX <a href="#release">release</a>?</p>
-              </div>
-            </section>
-          </div>
+   
         </article>
 
         <aside class="content__supplementary">

--- a/operators.html
+++ b/operators.html
@@ -7,7 +7,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
 
-  <title>Documentation for edx.org and the Open edX community | edX</title>
+  <title>Documentation for the Open edX community | edX</title>
   <meta name="description" content="">
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
@@ -47,7 +47,7 @@
             </abbr>
           </h1>
 
-          <h2 class="header__tagline">Documentation for edx.org and the Open edX Community</h2>
+          <h2 class="header__tagline">Documentation for the Open edX Community</h2>
         </div>
       </header>
     </div>
@@ -59,59 +59,31 @@
 
           <div class="list--docs">
             <section class="item-audience item-audience--partners">
-              <h3 class="item-audience__title"><a name="partners"></a>edX Documentation Resources</h3>
+              <h3 class="item-audience__title"><a name="operators"></a>Documentation Resources for Open edX Operators</h3>
 
               <div class="item-audience__copy">
-                <p>EdX provides user documentation for a variety of audiences: edx.org learners, course teams, developers, and researchers. </p>
+                <p>Information about setting up and operating your own instance of the Open edX platform.</p>
               </div>
 
               <ul class="list--links">
 
                 <li class="item-link">
-                  <a class="item-link__action" href="https://support.edx.org/hc/en-us/">
-                    <h4 class="item-link__title">Learners</h4>
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-hawthorn.master/">
+                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform: Hawthorn Release</h4>
                     <div class="item-link__copy">
-                      <p>Are you a learner taking a course on edx.org? Get help from the EdX Learner Help Center.</p>
+                      <p>Instructions for system administrators setting up an Open edX installation, using Hawthorn, the latest supported release of Open edX.</p>
                     </div>
                   </a>
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/course-staff.html">
-                    <h4 class="item-link__title">Course Teams</h4>
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/hawthorn.html">
+                    <h4 class="item-link__title">Hawthorn Release Notes</h4>
                     <div class="item-link__copy">
-                      <p>Information and instructions for course teams that are creating courses to run on the edx.org website.</p>
+                      <p>Summary of the changes in the Hawthorn release of the Open edX platform.</p>
                     </div>
                   </a>
                 </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/">
-                    <h4 class="item-link__title">Developers</h4>
-                    <div class="item-link__copy">
-                      <p>Guidelines and resources for developers who are extending and contributing to the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/operators.html">
-                    <h4 class="item-link__title">Open edX Operators</h4>
-                    <div class="item-link__copy">
-                      <p>Information about setting up and operating instances of the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/researchers.html">
-                    <h4 class="item-link__title">Researchers</h4>
-                    <div class="item-link__copy">
-                      <p>Descriptions of the visualizations, metrics, and tables that present edx.org course data to edX partner course teams, researchers, and data czars.</p>
-                    </div>
-                  </a>
-                </li>
-
               </ul>
             </section>
    

--- a/researchers.html
+++ b/researchers.html
@@ -47,7 +47,7 @@
             </abbr>
           </h1>
 
-          <h2 class="header__tagline">Documentation for edx.org and the Open edX Community</h2>
+          <h2 class="header__tagline">Documentation for edx.org Partners</h2>
         </div>
       </header>
     </div>
@@ -59,60 +59,32 @@
 
           <div class="list--docs">
             <section class="item-audience item-audience--partners">
-              <h3 class="item-audience__title"><a name="partners"></a>edX Documentation Resources</h3>
+              <h3 class="item-audience__title"><a name="partners"></a>Documentation Resources for edx.org Partner Researchers</h3>
 
               <div class="item-audience__copy">
-                <p>EdX provides user documentation for a variety of audiences: edx.org learners, course teams, developers, and researchers. </p>
+                <p>Information for edX partner researchers and course teams about how to use edX Insights and the edX reearch package.</p>
               </div>
 
               <ul class="list--links">
 
                 <li class="item-link">
-                  <a class="item-link__action" href="https://support.edx.org/hc/en-us/">
-                    <h4 class="item-link__title">Learners</h4>
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-insights/en/latest/">
+                    <h4 class="item-link__title">Using edX Insights</h4>
                     <div class="item-link__copy">
-                      <p>Are you a learner taking a course on edx.org? Get help from the EdX Learner Help Center.</p>
+                      <p>Descriptions of the visualizations, metrics, and tables that present edx.org course data to course teams.</p>
                     </div>
                   </a>
                 </li>
 
                 <li class="item-link">
                   <a class="item-link__action" href="http://docs.edx.org/course-staff.html">
-                    <h4 class="item-link__title">Course Teams</h4>
+                    <h4 class="item-link__title">EdX Research Guide</h4>
                     <div class="item-link__copy">
-                      <p>Information and instructions for course teams that are creating courses to run on the edx.org website.</p>
+                      <p>A reference for edX partner researchers and data czars who use the edX data package to to gain insight into their courses and students.</p>
                     </div>
                   </a>
                 </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/">
-                    <h4 class="item-link__title">Developers</h4>
-                    <div class="item-link__copy">
-                      <p>Guidelines and resources for developers who are extending and contributing to the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/operators.html">
-                    <h4 class="item-link__title">Open edX Operators</h4>
-                    <div class="item-link__copy">
-                      <p>Information about setting up and operating instances of the Open edX platform.</p>
-                    </div>
-                  </a>
-                </li>
-
-                <li class="item-link">
-                  <a class="item-link__action" href="http://docs.edx.org/researchers.html">
-                    <h4 class="item-link__title">Researchers</h4>
-                    <div class="item-link__copy">
-                      <p>Descriptions of the visualizations, metrics, and tables that present edx.org course data to edX partner course teams, researchers, and data czars.</p>
-                    </div>
-                  </a>
-                </li>
-
-              </ul>
+          </ul>
             </section>
    
         </article>


### PR DESCRIPTION
Here's a draft index page for docs.edx.org. It's intended to send each audience to a separate sub-index that lists all the doc resources that are relevant for that audience, instead of listing them all on the front page. I've used placeholder URLs for most of the sub-indices.