### PR TITLE
Add subindex page for Open edX

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,15 @@
                 </li>
 
                 <li class="item-link">
+                  <a class="item-link__action" href="http://docs.edx.org/openedx.html">
+                    <h4 class="item-link__title">Open edX Release Documentation</h4>
+                    <div class="item-link__copy">
+                      <p>Links to documentation for the most recent releases of the Open edX platform.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
                   <a class="item-link__action" href="http://docs.edx.org/researchers.html">
                     <h4 class="item-link__title">Researchers</h4>
                     <div class="item-link__copy">

--- a/openedx.html
+++ b/openedx.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]><html class="no-js lt-ie9 lt-ie8 lt-ie7" lang="en"><![endif]-->
+<!--[if IE 7]><html class="no-js lt-ie9 lt-ie8" lang="en"><![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en"><![endif]-->
+<!--[if gt IE 8]><!--><html class="no-js" lang="en"><!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+
+  <title>Documentation for the Open edX community | edX</title>
+  <meta name="description" content="">
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+
+  <link type="text/css" rel="stylesheet" href="edx-docs/assets/css/main.css" media="screen, projection" />
+  <script type="text/javascript" src="edx-docs/assets/js/vendor/modernizr.min.js"></script>
+
+  <script>
+   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+   ga('create', 'UA-50141783-1', 'edx.org');
+   ga('send', 'pageview');
+ </script>
+</head>
+
+<body class="view--index">
+  <div class="wrapper--view">
+
+    <div class="wrapper--header">
+      <header class="header--primary" role="banner">
+        <span class="wrapper--logo">
+          <span class="depth-left"></span>
+            <a href="http://www.edx.org"><img class="logo-edx is-hanging" src="edx-docs/assets/images/logo-edx.png" alt="edX" /></a>
+          <span class="depth-right"></span>
+        </span>
+
+        <div class="wrapper--title">
+          <h1 class="header__title">
+            <span class="sr">edX</span>
+            <abbr class="logo-docs" title="Documentation">
+              <i class="icon-file-text"></i>
+              Docs
+            </abbr>
+          </h1>
+
+          <h2 class="header__tagline">Documentation for the Open edX Community</h2>
+        </div>
+      </header>
+    </div>
+
+    <div class="wrapper--content">
+      <div class="content content--view">
+
+        <article class="content__main">
+
+          <div class="list--docs">
+           
+            <section class="item-audience item-audience--release">
+              <h3 class="item-audience__title"><a name="release"></a><a name="hawthorn"></a>Open edX: Hawthorn Release</h3>
+
+              <div class="item-audience__copy">
+                <p>Documentation for the Hawthorn Open edX release, available 7 August 2018. </p>
+              </div>
+
+              <ul class="list--links">
+               <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/hawthorn.html">
+                    <h4 class="item-link__title">Hawthorn Release Notes</h4>
+                    <div class="item-link__copy">
+                      <p>Summary of the changes in the Hawthorn release of the Open edX platform.</p>
+                    </div>
+                  </a>
+                </li>  
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-hawthorn.master/">
+                    <h4 class="item-link__title">Building and Running an Open edX Course: Hawthorn Release</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-hawthorn.master/">
+                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform: Hawthorn Release</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for system administrators setting up an Open edX installation.</p>
+                    </div>
+                  </a>
+                </li>
+
+
+              </ul>
+
+            </section>
+
+            <section class="item-audience item-audience--release">
+              <h3 class="item-audience__title"><a name="release"></a><a name="ginkgo"></a>Open edX: Ginkgo Release</h3>
+
+              <div class="item-audience__copy">
+                <p>Documentation for the Ginkgo Open edX release, available 15 August 2017. </p>
+              </div>
+
+              <ul class="list--links">
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/ginkgo.html">
+                    <h4 class="item-link__title">Ginkgo Release Notes</h4>
+                    <div class="item-link__copy">
+                      <p>Summary of the changes in the Ginkgo release of the Open edX platform.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-ginkgo.master/">
+                    <h4 class="item-link__title">Building and Running an Open edX Course: Ginkgo Release</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-ginkgo.master/">
+                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform: Ginkgo Release</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for system administrators setting up an Open edX installation.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-ginkgo.master/">
+                    <h4 class="item-link__title">Open edX Learner's Guide: Ginkgo Release</h4>
+                    <div class="item-link__copy">
+                      <p>Information for learners taking an Open edX course.</p>
+                    </div>
+                  </a>
+                </li>
+
+              </ul>
+
+            </section>
+
+            <section class="item-audience item-audience--release">
+              <h3 class="item-audience__title"><a name="latest"></a>Open edX: "Latest" Documentation</h3>
+
+              <div class="item-audience__copy">
+                <p>Documentation for Open edX users who are following the master version of the platform.
+                These guides can include changes made after the Hawthorn release.</p>
+              </div>
+
+              <ul class="list--links">
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/">
+                    <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for system administrators setting up an Open edX installation.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/">
+                    <h4 class="item-link__title">Building and Running an Open edX Course</h4>
+                    <div class="item-link__copy">
+                      <p>Instructions for course teams that are creating courses to run on an Open edX site.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-learner-guide/en/latest/">
+                    <h4 class="item-link__title">Open edX Learner's Guide</h4>
+                    <div class="item-link__copy">
+                      <p>Help for learners taking an Open edX course.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/">
+                    <h4 class="item-link__title">edX Open Learning XML Guide - Alpha Version</h4>
+                    <div class="item-link__copy">
+                      <p>Reference for course teams who use open learning XML (OLX) to build courses.</p>
+                    </div>
+                  </a>
+                </li>
+              </ul>
+              <div class="item-audience__copy">
+                <p>Looking for documentation for the last Open edX <a href="#release">release</a>?</p>
+              </div>
+            </section>
+
+                        <section class="item-audience item-audience--release">
+              <h3 class="item-audience__title"><a name="dev"></a>Documentation for Developers</h3>
+
+              <div class="item-audience__copy">
+                <p>Are you a developer who is extending and contributing to the Open edX platform? See these <a href="https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/">developer documentation resources.</a></p>
+              </div>
+
+            </section>
+
+
+          </div>
+        </article>
+
+        <aside class="content__supplementary">
+
+          <div class="info">
+            <h2 class="info__title">Feedback or Questions about edX Documentation</h2>
+
+            <div class="info__copy">
+
+              <p>EdX welcomes and appreciates your comments on and requests for documentation. Just email us at <a href="mailto:docs@edx.org">docs@edx.org</a>.</p>
+              <br />
+              <br />
+        <p><a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a><br>
+        These works by <a xmlns:cc="http://creativecommons.org/ns#" href="http://open.edx.org" property="cc:attributionName" rel="cc:attributionURL">edX Inc.</a> are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+    <footer class="footer--primary" role="contentinfo">
+      <div class="content--copyright">
+        <p class="copyright__copy">Copyright &copy; 2018 <a href="http://www.edx.org">edX Inc.</a></p>
+      </div>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Adding a page that lists all the Hawthorn, Gingko, and latest docs for Open edX. This might someday be better located within an Open edX portal.