### PR TITLE
feat: add link to search

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,20 +124,33 @@
 
               </ul>
             </section>
+          </div>
         </article>
 
         <aside class="content__supplementary">
 
           <div class="info">
-            <h2 class="info__title">Feedback or Questions about edX Documentation</h2>
-
+            <h2 class="info__title">Search edX Documentation</h2>
             <div class="info__copy">
+              <p>
+                Search Open edX information across ReadTheDocs, Confluence wiki, JIRA tickets, Discourse, and documents in GitHub. Just go to the <a href="http://docs.edx.org/search.html">search page</a>.
+              </p>
+            </div>
+          </div>
 
-              <p>edX welcomes and appreciates your comments on and requests for documentation. Just email us at <a href="mailto:docs@edx.org">docs@edx.org</a>.</p>
+          <div class="info">
+            <h2 class="info__title">Feedback or Questions about edX Documentation</h2>
+            <div class="info__copy">
+              <p>
+                edX welcomes and appreciates your comments on and requests for documentation. Just email us at <a href="mailto:docs@edx.org">docs@edx.org</a>.
+              </p>
               <br />
               <br />
-        <p><a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a><br>
-        These works by <a xmlns:cc="http://creativecommons.org/ns#" href="http://open.edx.org" property="cc:attributionName" rel="cc:attributionURL">edX Inc.</a> are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</p>
+              <p>
+                <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" /></a>
+                <br />
+                These works by <a xmlns:cc="http://creativecommons.org/ns#" href="http://open.edx.org" property="cc:attributionName" rel="cc:attributionURL">edX Inc.</a> are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+              </p>
             </div>
           </div>
         </aside>


### PR DESCRIPTION
Adds the **Search edX Documentation** section. 

<img width="1154" alt="Screen Shot 2021-08-10 at 12 18 06 PM" src="https://user-images.githubusercontent.com/4252738/128824707-cff52606-918f-4ca3-a465-a7202c11cc3b.png">

@leangseu-edx 