### PR TITLE
fix: maple docs should link to maple, not lilac

### DIFF
--- a/operators.html
+++ b/operators.html
@@ -68,7 +68,7 @@
               <ul class="list--links">
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-lilac.master/">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/open-release-maple.master/">
                     <h4 class="item-link__title">Installing, Configuring, and Running the Open edX Platform: Maple Release</h4>
                     <div class="item-link__copy">
                       <p>Instructions for system administrators setting up an Open edX installation, using Maple, the latest supported release of Open edX.</p>
@@ -77,7 +77,7 @@
                 </li>
 
                 <li class="item-link">
-                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/lilac.html">
+                  <a class="item-link__action" href="http://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/maple.html">
                     <h4 class="item-link__title">Maple Release Notes</h4>
                     <div class="item-link__copy">
                       <p>Summary of the changes in the Maple release of the Open edX platform.</p>


### PR DESCRIPTION
This will need to be updated again in June, when nutmeg is released. 