### PR TITLE
feat: link to documentors and translators

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,19 +57,12 @@
       <div class="content content--view">
 
         <article class="content__main">
-          <div class="search-description__copy">
-            <p>Search Open edX information across ReadTheDocs, Confluence wiki, JIRA tickets, Discourse, and documents in GitHub.</p>
-            <div class="gcse-searchbox"></div>
-            <div class="gcse-searchresults"></div>
-          </div>
-
-
           <div class="list--docs">
             <section class="item-audience item-audience--partners">
               <h3 class="item-audience__title"><a name="partners"></a>edX Documentation Resources</h3>
 
               <div class="item-audience__copy">
-                <p>edX provides user documentation for a variety of audiences: edx.org learners, course teams, developers, and researchers. </p>
+                <p>We have documentation for a variety of audiences:</p>
               </div>
 
               <ul class="list--links">
@@ -78,7 +71,7 @@
                   <a class="item-link__action" href="https://support.edx.org/hc/en-us/">
                     <h4 class="item-link__title">Learners</h4>
                     <div class="item-link__copy">
-                      <p>Are you a learner taking a course on edx.org? Get help from the EdX Learner Help Center.</p>
+                      <p>Are you a learner taking a course on edx.org? Get help from the edX Learner Help Center.</p>
                     </div>
                   </a>
                 </li>
@@ -129,12 +122,36 @@
                   </a>
                 </li>
 
+                <li class="item-link">
+                  <a class="item-link__action" href="https://docs.openedx.org/en/latest/documentors/index.html">
+                    <h4 class="item-link__title">Documentors</h4>
+                    <div class="item-link__copy">
+                      <p>Information for helping to write and extend the Open edX documentation.</p>
+                    </div>
+                  </a>
+                </li>
+
+                <li class="item-link">
+                  <a class="item-link__action" href="https://docs.openedx.org/en/latest/translators/index.html">
+                    <h4 class="item-link__title">Translators</h4>
+                    <div class="item-link__copy">
+                      <p>Information and help for those adding translations to the Open edX software.</p>
+                    </div>
+                  </a>
+                </li>
+
               </ul>
             </section>
           </div>
         </article>
 
         <aside class="content__supplementary">
+          <div class="search-description__copy">
+            <h2 class="info__title">Search</h2>
+            <p>Search Open edX information across ReadTheDocs, Confluence wiki, JIRA tickets, Discourse, and documents in GitHub.</p>
+            <div class="gcse-searchbox"></div>
+            <div class="gcse-searchresults"></div>
+          </div>
 
           <div class="info">
             <h2 class="info__title">Feedback or Questions about edX Documentation</h2>
@@ -156,8 +173,8 @@
 
       <footer class="footer--primary" role="contentinfo">
         <div class="content--copyright">
-          <p class="copyright__copy">Copyright &copy; 2018&ndash;2022 <a href="http://www.edx.org">edX Inc.</a>
-          edX and Open edX are registered trademarks of edX LLC. MicroMasters and MicroBachelors are registered trademarks of The Center for Reimagining Learning. All Rights Reserved.
+          <p class="copyright__copy">Copyright &copy; 2018&ndash;2023 <a href="http://www.edx.org">edX Inc.</a>
+          edX and Open edX are registered trademarks of edX LLC. MicroMasters and MicroBachelors are registered trademarks of Axim Collaborative. All Rights Reserved.
           </p>
         </div>
       </footer>


### PR DESCRIPTION
Also, correct the trademark and copyright footers, and move search lower down.

How the changes look:
<img width="888" alt="image" src="https://user-images.githubusercontent.com/23789/236517867-f492c890-b556-4c38-92c8-da4015385eaf.png">
