### PR TITLE
fix: update font import URLs to use HTTPS

### DIFF
--- a/edx-docs/assets/css/main.css
+++ b/edx-docs/assets/css/main.css
@@ -1,5 +1,5 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,700,300);
-@import url(http://fonts.googleapis.com/css?family=Bree+Serif);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,700,300);
+@import url(https://fonts.googleapis.com/css?family=Bree+Serif);
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;

--- a/edx-docs/assets/sass/assets/_fonts.scss
+++ b/edx-docs/assets/sass/assets/_fonts.scss
@@ -2,10 +2,10 @@
 // ====================
 
 // import from google fonts - Open Sans
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,700,300);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,700,300);
 
 // import from google fonts - Bree
-@import url(http://fonts.googleapis.com/css?family=Bree+Serif);
+@import url(https://fonts.googleapis.com/css?family=Bree+Serif);
 
 // icons
 @import '../vendor/font-awesome'; // font awesome icons


### PR DESCRIPTION
### Description:

Updates Google Fonts imports to use HTTPS to avoid mixed-content issues when serving docs over TLS.

**JIRA ticket:**

- https://2u-internal.atlassian.net/browse/BOMS-484